### PR TITLE
Fix GA event payload for `ctb_modal_opened` event

### DIFF
--- a/static/ctb.js
+++ b/static/ctb.js
@@ -54,11 +54,11 @@
 			data: {
                 action: 'ctb_modal_opened',
                 data: {
-                    label: e.target.innerText,
-                    ctbId: ctbId,
-                    brand: window.nfdgctb.brand,
-                    context: determineContext(e),
-                    page: window.location.href
+                    'label_key': 'ctb_id',
+                    'ctb_id': ctbId,
+                    'brand': window.nfdgctb.brand,
+                    'context': determineContext(e),
+                    'page': window.location.href
                 }
             }
 		});


### PR DESCRIPTION
This PR aims to fix an issue where `ctb_modal_opened` event is not showing any of its parameters in GA.

![Analytics-Realtime-overview (1)](https://github.com/newfold-labs/wp-module-global-ctb/assets/38976631/f6ac29f2-0e28-4c4b-9958-820eeb6b35b3)
