### PR TITLE
add ndf-runtime as dependency of global ctb script

### DIFF
--- a/includes/CTB.php
+++ b/includes/CTB.php
@@ -52,7 +52,7 @@ class CTB {
 		wp_enqueue_script(
 			'newfold-global-ctb',
 			$assetsDir . 'ctb.js',
-			array( 'a11y-dialog' ),
+			array( 'a11y-dialog', 'nfd-runtime' ),
 			container()->plugin()->version,
 			true
 		);


### PR DESCRIPTION
Since the ctb script relies on the nfd-runtime object, it needs to be marked as a dependency for the ctb script. The runtime is on the plugin screens, but the ctbs are throughout the wp-admin screens and not just on the plugin screens, so runtime needs to be added everywhere the ctbs are possible.