### PR TITLE
require api-fetch script as dependency too

### DIFF
--- a/includes/CTB.php
+++ b/includes/CTB.php
@@ -52,7 +52,7 @@ class CTB {
 		wp_enqueue_script(
 			'newfold-global-ctb',
 			$assetsDir . 'ctb.js',
-			array( 'a11y-dialog', 'nfd-runtime' ),
+			array( 'a11y-dialog', 'wp-api-fetch', 'nfd-runtime' ),
 			container()->plugin()->version,
 			true
 		);


### PR DESCRIPTION
In HG on the plugins page we're missing the api-fetch lib. This update will require that as a dependency for global ctb script.

Uncaught TypeError: window.wp.apiFetch is not a function
    at ctbClickEvent (ctb.js?ver=2.4.0:51:19)
    at loadCtb (ctb.js?ver=2.4.0:12:9)
    at HTMLDivElement.<anonymous> (ctb.js?ver=2.4.0:177:25)