### PR TITLE
Fix `insertAdjacentElement` call

### DIFF
--- a/static/ctb.js
+++ b/static/ctb.js
@@ -126,7 +126,7 @@
             ctbContainer = document.createElement('div');
             ctbContainer.setAttribute('id', 'nfd-global-ctb-container');
             ctbContainer.innerHTML = modalContent;
-            ctbContainer.target.insertAdjacentElement('afterend', nfd - global - ctb - container);
+            ctbContainer.target.insertAdjacentElement('afterend', ctbContainer);
         }
 
         ctbContainer.setAttribute('data-ctb-id', ctbId);


### PR DESCRIPTION
## Proposed changes

In the event that there is no CTB container present, there is a bug that will prevent the container from being added. This fixes that error.

## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

This is a quick fix opened via GitHub; it has NOT been officially tested.