### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required to clone the repo (matches reusable workflow; private repo checkout).
+    timeout-minutes: 90
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -45,6 +47,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required to clone the repo (matches reusable workflow; private repo checkout).
+    timeout-minutes: 90
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -58,6 +61,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required to clone the repo (matches reusable workflow; private repo checkout).
+    timeout-minutes: 90
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -1,6 +1,4 @@
 name: Build and Test Module Updates in Brand Plugins (Playwright tests)
-permissions:
-  contents: read
 on:
   pull_request:
     types: [ opened, reopened, ready_for_review, synchronize ]
@@ -12,10 +10,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -28,6 +31,8 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
+    permissions:
+      contents: read # Required to clone the repo (matches reusable workflow; private repo checkout).
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -38,6 +43,8 @@ jobs:
   bluehost-dev:
     name: Bluehost DEV Build and Test Playwright
     needs: setup
+    permissions:
+      contents: read # Required to clone the repo (matches reusable workflow; private repo checkout).
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -49,6 +56,8 @@ jobs:
   hostgator:
     name: Hostgator Build and Test Playwright
     needs: setup
+    permissions:
+      contents: read # Required to clone the repo (matches reusable workflow; private repo checkout).
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to push coverage reports to gh-pages.
       pull-requests: write # Required for reusable workflow to post pull request comments.
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -29,8 +31,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for reusable workflow to push coverage reports to gh-pages.
+      pull-requests: write # Required for reusable workflow to post pull request comments.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
       actions: write # Required for actions/cache to store cache entries in private repositories.
       contents: read # Required to clone the repo.
       pull-requests: read # Required for technote-space/get-diff-action (default github.token API usage).
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      actions: write # Required for actions/cache to store cache entries in private repositories.
+      contents: read # Required to clone the repo.
+      pull-requests: read # Required for technote-space/get-diff-action (default github.token API usage).
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,16 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo.
+    timeout-minutes: 15
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 4 (`brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `lint.yml`, `satis-webhook.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `0a5a33f` |
| Timeouts commit | `92f24e1` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `contents: read` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `actions: write`, `contents: read`, `pull-requests: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | bluehost | `contents: read` [2] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | bluehost-dev | `contents: read` [2] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | hostgator | `contents: read` [2] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: `get-repo-name` (effective inherited access): BEFORE workflow-wide `contents: read` inherited by all jobs -> AFTER explicit `permissions: {}` on the job -- reason: the job only writes `github.repository` context to an output and does not check out the repo or call the GitHub API -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: `setup` (effective inherited access): BEFORE workflow-wide `contents: read` inherited by all jobs -> AFTER explicit `permissions: {}` on the job -- reason: the job only derives a branch name from environment/refs and does not check out the repo or call the GitHub API -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-webhook.yml | webhook | `15` | release-triggered webhook plus `actions/checkout` and a Repository Dispatch using `secrets.WEBHOOK_TOKEN`; short ceiling is sufficient versus long test matrices. |
| lint.yml | phpcs | `30` | Composer install and PHPCS over changed PHP paths; typical CI lint duration with cache restore. |
| codecoverage-main.yml | get-repo-name | `5` | single-step output extraction with no external services. |
| codecoverage-main.yml | codecoverage | `120` | calls `reusable-codecoverage.yml` with a multi-version PHP matrix, WordPress/Codeception-style testing, and gh-pages / PR bot operations that can run longer than a simple lint job. |
| brand-plugin-test-playwright.yml | setup | `5` | branch extraction only. |
| brand-plugin-test-playwright.yml | bluehost | `90` | reusable Playwright workflow builds multiple repos, runs `wp-env`, and installs Chromium; needs a higher ceiling than lint. |
| brand-plugin-test-playwright.yml | bluehost-dev | `90` | same rationale as `bluehost`, against `develop` for the brand plugin. |
| brand-plugin-test-playwright.yml | hostgator | `90` | same rationale as `bluehost` for a different brand plugin repository. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Callable jobs use `newfold-labs/workflows` reusable workflows (`reusable-codecoverage.yml`, `module-plugin-test-playwright.yml`) reviewed via their published `@main` sources; behavior that depends on newer upstream edits should be revalidated periodically. |
| 2 | `technote-space/get-diff-action` defaults to `${{ github.token }}`; `pull-requests: read` was granted based on that default token usage (see `action.yml`). If future versions change token usage, re-audit this job. |
| 3 | Confidence `[2]` on brand-plugin callable jobs reflects that their minimal GitHub token surface is aligned to the reusable workflow’s documented `contents: read`, but artifact upload behavior can be sensitive to GitHub’s evolving permission requirements for `actions/upload-artifact` in private repositories—worth a quick production run confirmation after merge. |


